### PR TITLE
FIX : error 처리 미들웨어 구현

### DIFF
--- a/backend/Middlewares/error404.js
+++ b/backend/Middlewares/error404.js
@@ -1,0 +1,7 @@
+const error404 = (req, res, next) => {
+  const error = new Error(`${req.method} ${req.url} 라우터가 없습니다.`);
+  error.status = 404;
+  next(error); // 다음 미들웨어로 에러를 전달합니다.
+}
+
+module.exports = error404;

--- a/backend/Middlewares/errorMiddleware.js
+++ b/backend/Middlewares/errorMiddleware.js
@@ -1,0 +1,23 @@
+
+const handleError = (err, req, res, next) => {
+  console.error(err.stack); // 에러 스택을 콘솔에 출력합니다.
+
+  // 기본적으로 사용할 에러 포맷
+  const errorResponse = {
+    code: err.status || 500, // HTTP 상태 코드를 사용하거나 기본적으로 500을 사용합니다.
+    message: err.message || '서버 에러입니다', // 에러 메시지를 사용하거나 기본적인 메시지를 사용합니다.
+    error: {
+      type: err.name || 'ServerError', // 에러 유형을 사용하거나 기본적으로 'ServerError'를 사용합니다.
+      message: err.message || '서버 에러입니다' // 상세한 메시지를 사용하거나 기본적인 메시지를 사용합니다.
+    }
+  };
+
+  // 개발 환경에서는 상세한 에러 스택 정보를 클라이언트에게 전달합니다.
+  if (process.env.NODE_ENV === 'development') {
+    errorResponse.error.stack = err.stack;
+  }
+
+  res.status(errorResponse.code).json(errorResponse);
+};
+
+module.exports = handleError;

--- a/backend/Middlewares/handleError.js
+++ b/backend/Middlewares/handleError.js
@@ -1,4 +1,3 @@
-
 const handleError = (err, req, res, next) => {
   console.error(err.stack); // 에러 스택을 콘솔에 출력합니다.
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -44,6 +44,6 @@ db.sequelize
       console.log(`${PORT}번 포트에서 서버 실행중 . . . `);
     });
   }).catch(err=>{
-    console.error('DB 연결 실패', err);
+    console.error('db 연결 실패', err);
   });
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,6 +4,8 @@ const session = require('express-session');
 const dotenv = require('dotenv');
 const cookieParser = require('cookie-parser');
 const db =require('./models');
+const error404 = require('./Middlewares/error404');
+const handleError = require('./Middlewares/handleError');
 
 const {userRouter, productRouter,renderRouter,reviewRouter}= require('./routes');
 
@@ -35,22 +37,10 @@ app.use(session({
 }))
 
 //404 에러처리 미들웨어
-app.use((req, res, next) => {
-  const error = new Error(`${req.method} ${req.url} 라우터가 없습니다.`);
-  error.status = 404;
-  next(error); // 다음 미들웨어로 에러를 전달합니다.
-});
+app.use(error404);
 
 //기타 에러처리 미들웨어
-app.use((err, req, res, next) => {
-  console.error(err.stack); // 에러 스택을 콘솔에 출력합니다.
-
-  res.status(err.status || 500)
-  .send({
-    message: err.message,
-    error: process.env.NODE_ENV === 'development' ? err : {} // 개발 환경에서는 상세한 에러 정보를 전달합니다.
-  });
-});
+app.use(handleError);
 
 
 app.listen(PORT,()=>{


### PR DESCRIPTION

## 작업내용 #33 

1. Middlewares 폴더에 error처리 미들웨어를 작성하였습니다.
2. app.js에서 에러 처리 로직을 만들었습니다.
    - 기본적으로 에러가 없는 화면으로 가지만, 라우터가 없다면 404 에러인지 확인하는 error404파일로 이동하여 에러를 처리해줍니다.
    - 404 에러가 아니라면, controller의 try-catch문의 catch문으로 이동하지만, next(err)를 통해 다음 미들웨어로 넘겨줍니다.
    - 다음 미들웨어로 넘어간다면 handleError 파일로 넘어가 정형화된 에러 response를 전송하게 됩니다.
