### PR TITLE
FEAT : 로그인, 비로그인 상태를 판별하는 라우터 경로 추가

### DIFF
--- a/backend/controller/renderController.js
+++ b/backend/controller/renderController.js
@@ -28,6 +28,31 @@ exports.main = async(req,res,next) => {
     next(err);
   }
 }
+
+exports.authCheck = async(req,res,next)=>{
+  try{
+    if(req.isAuthenticated()){
+      return res.status(200).json({
+        code:200,
+        message:"로그인된 사용자입니다.",
+        data:{
+          isAuthenticated:true
+        }
+      })
+    }else{
+      return res.status(200).json({
+        code:200,
+        message:"비로그인 사용자입니다.",
+        data:{
+          isAuthenticated:false
+        }
+      })
+    };
+  }catch(err){
+    next(err);
+  }
+}
+
 //마이 페이지 렌더링
 exports.mypage = async(req,res,next) =>{
   try{

--- a/backend/routes/renderRouter.js
+++ b/backend/routes/renderRouter.js
@@ -6,6 +6,8 @@ const isLoggedIn = require('../Middlewares/isLoggedIn');
 //메인 페이지 렌더링
 router.get('/main', controller.main);
 
+router.get('/auth/check', controller.authCheck);
+
 //마이 페이지 렌더링
 router.get('/mypage', isLoggedIn, controller.mypage);
 


### PR DESCRIPTION
## 로그인, 비로그인 상태를 판별하는 라우터 경로 추가
### 작업 내용
- #62 
- /auth/check에 axios get 요청을 받으면, 현재 로그인 여부를 판별해줍니다.
---
### 경로
`GET` `/auth/check`